### PR TITLE
Log object counts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     "!src/index.ts",
     "!src/TenableClient.ts",
     "!src/converters.ts",
+    "!src/utils/logObjectCounts.ts",
   ],
   moduleFileExtensions: [...defaults.moduleFileExtensions, "ts"],
   testEnvironment: "node",

--- a/src/executionHandler.test.ts
+++ b/src/executionHandler.test.ts
@@ -31,6 +31,9 @@ const executionContext: any = {
     id: "TestId",
     name: "TestName",
   },
+  logger: {
+    info: jest.fn(),
+  },
 };
 
 (initializeContext as jest.Mock).mockReturnValue(executionContext);

--- a/src/executionHandler.ts
+++ b/src/executionHandler.ts
@@ -13,6 +13,7 @@ import fetchEntitiesAndRelationships from "./jupiterone/fetchEntitiesAndRelation
 import publishChanges from "./persister/publishChanges";
 import fetchTenableData from "./tenable/fetchTenableData";
 import { TenableIntegrationContext } from "./types";
+import logObjectCounts from "./utils/logObjectCounts";
 
 export default async function executionHandler(
   context: IntegrationExecutionContext,
@@ -32,6 +33,8 @@ async function synchronize(
 
   const oldData = await fetchEntitiesAndRelationships(graph);
   const tenableData = await fetchTenableData(provider);
+
+  logObjectCounts(context, oldData, tenableData);
 
   return {
     operations: summarizePersisterOperationsResults(

--- a/src/utils/logObjectCounts.ts
+++ b/src/utils/logObjectCounts.ts
@@ -1,0 +1,48 @@
+import { JupiterOneDataModel } from "../jupiterone/fetchEntitiesAndRelationships";
+import { Dictionary, TenableDataModel } from "../tenable/types";
+import { TenableIntegrationContext } from "../types";
+
+export default function logObjectCounts(
+  context: TenableIntegrationContext,
+  oldData: JupiterOneDataModel,
+  tenableData: TenableDataModel,
+) {
+  const graphEntityCounts: {
+    [objectName: string]: number;
+  } = {};
+  for (const [k, v] of Object.entries(oldData.entities)) {
+    graphEntityCounts[k] = v.length;
+  }
+
+  const graphRelationshipCounts: {
+    [objectName: string]: number;
+  } = {};
+  for (const [k, v] of Object.entries(oldData.relationships)) {
+    graphRelationshipCounts[k] = v.length;
+  }
+
+  const countDictionary = (dict: Dictionary<any>) =>
+    Object.values(dict).reduce((c, h) => c + h.length, 0);
+
+  const tenableDataCounts = {
+    assets: tenableData.assets.length,
+    containers: tenableData.containers.length,
+    scans: tenableData.scans.length,
+    users: tenableData.users.length,
+    containerFindings: countDictionary(tenableData.containerFindings),
+    containerMalwares: countDictionary(tenableData.containerMalwares),
+    containerUnwantedPrograms: countDictionary(
+      tenableData.containerUnwantedPrograms,
+    ),
+    scanVulnerabilities: countDictionary(tenableData.scanVulnerabilities),
+  };
+
+  context.logger.info(
+    {
+      graphEntityCounts,
+      graphRelationshipCounts,
+      tenableDataCounts,
+    },
+    "Loaded data for synchronization",
+  );
+}


### PR DESCRIPTION
A start to getting more info, produces the following log content:

```
    graphEntityCounts: {
      "accounts": 1,
      "users": 1,
      "assets": 2,
      "scans": 2,
      "vulnerabilities": 0,
      "vulnerabilityFindings": 0,
      "containers": 1,
      "containerReports": 1,
      "containerMalwares": 0,
      "containerFindings": 3,
      "containerUnwantedPrograms": 0
    }
    --
    graphRelationshipCounts: {
      "accountUserRelationships": 1,
      "userScanRelationships": 2,
      "scanVulnerabilityRelationships": 0,
      "vulnerabilityFindingRelationships": 0,
      "scanFindingRelationships": 0,
      "scanAssetRelationships": 2,
      "assetScanVulnerabilityRelationships": 0,
      "accountContainerRelationships": 1,
      "containerReportRelationships": 1,
      "reportMalwareRelationships": 0,
      "reportFindingRelationships": 3,
      "reportUnwantedProgramRelationships": 0
    }
    --
    tenableDataCounts: {
      "assets": 2,
      "containers": 1,
      "scans": 2,
      "users": 1,
      "containerFindings": 3,
      "containerMalwares": 0,
      "containerUnwantedPrograms": 0,
      "scanVulnerabilities": 17
    }
```