### PR TITLE
Add request logging information

### DIFF
--- a/src/executionHandler.ts
+++ b/src/executionHandler.ts
@@ -39,7 +39,7 @@ async function synchronize(
   return {
     operations: summarizePersisterOperationsResults(
       await removeDeprecatedEntities(graph, persister),
-      await publishChanges(persister, oldData, tenableData, account),
+      await publishChanges({ persister, oldData, tenableData, account }),
     ),
   };
 }

--- a/src/initializeContext.ts
+++ b/src/initializeContext.ts
@@ -5,9 +5,16 @@ import { Account, TenableIntegrationContext } from "./types";
 export default async function initializeContext(
   context: IntegrationExecutionContext,
 ): Promise<TenableIntegrationContext> {
-  const { config } = context.instance;
+  const {
+    logger,
+    instance: { config },
+  } = context;
 
-  const provider = new TenableClient(config.accessKey, config.secretKey);
+  const provider = new TenableClient(
+    logger,
+    config.accessKey,
+    config.secretKey,
+  );
 
   const { persister, graph } = context.clients.getClients();
 

--- a/src/invocationValidator.ts
+++ b/src/invocationValidator.ts
@@ -24,14 +24,21 @@ import TenableClient from "./tenable/TenableClient";
 export default async function invocationValidator(
   executionContext: IntegrationValidationContext,
 ) {
-  const { config } = executionContext.instance;
+  const {
+    logger,
+    instance: { config },
+  } = executionContext;
   if (!config.accessKey || !config.secretKey) {
     throw new IntegrationInstanceConfigError(
       "config requires all of { accessKey, secretKey }",
     );
   }
 
-  const provider = new TenableClient(config.accessKey, config.secretKey);
+  const provider = new TenableClient(
+    logger,
+    config.accessKey,
+    config.secretKey,
+  );
 
   try {
     await provider.fetchUsers();

--- a/src/persister/index.ts
+++ b/src/persister/index.ts
@@ -41,13 +41,18 @@ import { Account } from "../types";
 type EntityDataNames = keyof JupiterOneEntitiesData;
 type RelationshipDataNames = keyof JupiterOneRelationshipsData;
 
-export async function publishChanges(
-  persister: PersisterClient,
-  oldData: JupiterOneDataModel,
-  tenableDataModel: TenableDataModel,
-  account: Account,
-) {
-  const newData = convert(tenableDataModel, account);
+export async function publishChanges({
+  persister,
+  account,
+  oldData,
+  tenableData,
+}: {
+  persister: PersisterClient;
+  account: Account;
+  oldData: JupiterOneDataModel;
+  tenableData: TenableDataModel;
+}) {
+  const newData = convert(tenableData, account);
 
   const entities = createEntitiesOperations(
     oldData.entities,

--- a/src/tenable/TenableClient.test.ts
+++ b/src/tenable/TenableClient.test.ts
@@ -1,4 +1,5 @@
 import nock from "nock";
+
 import { fetchTenableData } from "./index";
 import TenableClient from "./TenableClient";
 import { Scan } from "./types";
@@ -21,15 +22,27 @@ describe("TenableClient fetch ok data", () => {
       : nock.back.setMode("record");
   });
 
-  async function getClient() {
-    return new TenableClient(ACCESS_KEY, SECRET_KEY);
+  function getClient() {
+    return new TenableClient(
+      { trace: jest.fn() } as any,
+      ACCESS_KEY,
+      SECRET_KEY,
+    );
   }
+
+  test("fetch error", async () => {
+    nock(`https://${CLUSTER}`)
+      .get("/users")
+      .reply(404);
+    const client = getClient();
+    await expect(client.fetchUsers()).rejects.toThrow();
+  });
 
   test("fetchUsers ok", async () => {
     const { nockDone } = await nock.back("users-ok.json", {
       before: prepareScope,
     });
-    const client = await getClient();
+    const client = getClient();
     const response = await client.fetchUsers();
     expect(response.length).not.toEqual(0);
     nockDone();
@@ -39,7 +52,7 @@ describe("TenableClient fetch ok data", () => {
     const { nockDone } = await nock.back("scans-ok.json", {
       before: prepareScope,
     });
-    const client = await getClient();
+    const client = getClient();
     const response = await client.fetchScans();
     expect(response.length).not.toEqual(0);
     nockDone();
@@ -49,14 +62,14 @@ describe("TenableClient fetch ok data", () => {
     const { nockDone } = await nock.back("assets-ok.json", {
       before: prepareScope,
     });
-    const client = await getClient();
+    const client = getClient();
     const response = await client.fetchAssets();
     expect(response.length).not.toEqual(0);
     nockDone();
   });
 
   test("fetchScan ok", async () => {
-    const client = await getClient();
+    const client = getClient();
 
     const { nockDone } = await nock.back("scan-ok.json", {
       before: prepareScope,
@@ -68,7 +81,7 @@ describe("TenableClient fetch ok data", () => {
   });
 
   test("fetchVulnerabilities ok", async () => {
-    const client = await getClient();
+    const client = getClient();
 
     const { nockDone } = await nock.back("vulnerabilities-ok.json", {
       before: prepareScope,
@@ -93,7 +106,7 @@ describe("TenableClient fetch ok data", () => {
     const { nockDone } = await nock.back("reports-ok.json", {
       before: prepareScope,
     });
-    const client = await getClient();
+    const client = getClient();
     const response = await client.fetchReportByImageDigest(
       "sha256:c42a932fda50763cb2a0169dd853f071a37629cfa4a477b81b4ee87c2b0bb3dc",
     );
@@ -105,7 +118,7 @@ describe("TenableClient fetch ok data", () => {
     const { nockDone } = await nock.back("all-data-ok.json", {
       before: prepareScope,
     });
-    const client = await getClient();
+    const client = getClient();
     const response = await fetchTenableData(client);
     nockDone();
     expect(response.users.length).not.toEqual(0);

--- a/src/tenable/types.ts
+++ b/src/tenable/types.ts
@@ -243,7 +243,7 @@ interface Folder {
 
 export interface ScanResponse {
   info: ScanInfo;
-  hosts: Host[];
+  hosts?: Host[];
   vulnerabilities: VulnerabilitySummary[];
 }
 


### PR DESCRIPTION
More logging, this time in the API client so we can see what is coming back from the API. There is no reason to suspect the operation generation since our previously added logging indicated there were no scan vulnerabilities, but we don't have a deep enough count to know why.