### PR TITLE
Fix errors

### DIFF
--- a/src/tenable/types.ts
+++ b/src/tenable/types.ts
@@ -37,7 +37,7 @@ export interface RecentScanSummary {
   read: boolean;
   last_modification_date: number;
   creation_date: number;
-  status: string;
+  status: ScanStatus;
   uuid: string;
   shared: boolean;
   user_permissions: number;
@@ -49,6 +49,22 @@ export interface RecentScanSummary {
   enabled: boolean;
   control: boolean;
   name: string;
+}
+
+export enum ScanStatus {
+  Completed = "completed",
+  Aborted = "aborted",
+  Empty = "empty",
+  Imported = "imported",
+  Pending = "pending",
+  Running = "running",
+  Resuming = "resuming",
+  Canceling = "canceling",
+  Canceled = "canceled",
+  Pausing = "pausing",
+  Paused = "paused",
+  Stopping = "stopping",
+  Stopped = "stopped",
 }
 
 // -- https://cloud.tenable.com/scans/:scanId

--- a/test/fixtures/asset-vulnerability-info-not-found.json
+++ b/test/fixtures/asset-vulnerability-info-not-found.json
@@ -1,0 +1,42 @@
+[
+  {
+    "scope": "https://cloud.tenable.com:443",
+    "method": "GET",
+    "path": "/workbenches/assets/2aa49a6b-f17b-4b43-8953-58e2012f2fb3/vulnerabilities/11111/info",
+    "body": "",
+    "status": 404,
+    "response": {
+      "error": "HTTP 404 Not Found"
+    },
+    "rawHeaders": [
+      "Date",
+      "Tue, 03 Sep 2019 21:23:54 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "30",
+      "Connection",
+      "close",
+      "Set-Cookie",
+      "nginx-cloud-site-id=us-2a; path=/; HttpOnly",
+      "X-Request-Uuid",
+      "69886503670141d9a2cdbcb1e4f1d491",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "DENY",
+      "X-Xss-Protection",
+      "1; mode=block",
+      "Cache-Control",
+      "no-cache",
+      "Vary",
+      "accept-encoding",
+      "Server",
+      "tenable.io",
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains",
+      "X-Gateway-Site-ID",
+      "nginx-router-c-prod-us-east-1"
+    ]
+  }
+]

--- a/test/fixtures/asset-vulnerability-info-ok.json
+++ b/test/fixtures/asset-vulnerability-info-ok.json
@@ -1,0 +1,77 @@
+[
+  {
+    "scope": "https://cloud.tenable.com:443",
+    "method": "GET",
+    "path": "/workbenches/assets/2aa49a6b-f17b-4b43-8953-58e2012f2fb3/vulnerabilities/10386/info",
+    "body": "",
+    "status": 200,
+    "response": {
+      "info": {
+        "count": 1,
+        "vuln_count": 1,
+        "description": "The remote web server is configured such that it does not return '404 Not Found' error codes when a nonexistent file is requested, perhaps returning instead a site map, search page or authentication page.\n\nNessus has enabled some counter measures for this.  However, they might be insufficient.  If a great number of security holes are produced for this port, they might not all be accurate.",
+        "synopsis": "The remote web server does not return 404 error codes.",
+        "discovery": {
+          "seen_first": "2019-07-18T15:22:59.649Z",
+          "seen_last": "2019-09-02T11:46:38.172Z"
+        },
+        "severity": 0,
+        "plugin_details": {
+          "family": "Web Servers",
+          "modification_date": "2015-10-13T00:00:00Z",
+          "name": "Web Server No 404 Error Code Check",
+          "publication_date": "2000-04-28T00:00:00Z",
+          "type": "remote",
+          "version": "$Revision: 1.98 $",
+          "severity": 0
+        },
+        "reference_information": [],
+        "risk_information": {
+          "risk_factor": "None",
+          "cvss_vector": null,
+          "cvss_base_score": null,
+          "cvss_temporal_vector": null,
+          "cvss_temporal_score": null,
+          "cvss3_vector": null,
+          "cvss3_base_score": null,
+          "cvss3_temporal_vector": null,
+          "cvss3_temporal_score": null,
+          "stig_severity": null
+        },
+        "see_also": []
+      }
+    },
+    "rawHeaders": [
+      "Date",
+      "Tue, 03 Sep 2019 21:15:26 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "1151",
+      "Connection",
+      "close",
+      "Set-Cookie",
+      "nginx-cloud-site-id=us-2a; path=/; HttpOnly",
+      "X-Request-Uuid",
+      "0305873fb62bcef32b79fac796fd22c0",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "DENY",
+      "X-Xss-Protection",
+      "1; mode=block",
+      "Cache-Control",
+      "no-cache",
+      "Vary",
+      "accept-encoding",
+      "Accept-Ranges",
+      "bytes",
+      "Server",
+      "tenable.io",
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains",
+      "X-Gateway-Site-ID",
+      "nginx-router-c-prod-us-east-1"
+    ]
+  }
+]


### PR DESCRIPTION
These changes address two issues:

1. When a scan is aborted, the details are blank, causing previously successful execution results to be wiped out during ingestion
2. Scan hosts with vulnerabilities might not have vulnerability details available

This latter issue seems to be, scans of type "ps" vulnerabilities do not have host-specific details available through the asset vulnerability APIs. Reviewing the vulnerabilities in the tenable UI, there are no details listed there either, so they don't appear to be available at all.